### PR TITLE
Add begin/end, use copy and swap idiom for moves

### DIFF
--- a/app/dynamicArray.h
+++ b/app/dynamicArray.h
@@ -34,9 +34,11 @@ public:
 
     T& operator[](const int index);
     const T& operator[](const int index) const;
-    void append(const T elem); //insert at the end
-    void insert(const T elem, const int index);
+    void append(const T& elem); //insert at the end
+    void insert(const T& elem, const int index);
     int size() const;
+    T* begin() const;
+    T* end() const;
 };
 
 template <typename T>
@@ -105,24 +107,23 @@ dynamicArray<T>& dynamicArray<T>::operator=(const dynamicArray& other)
 }
 
 template <typename T>
-dynamicArray<T>::dynamicArray(dynamicArray&& other) noexcept
+dynamicArray<T>::dynamicArray(dynamicArray&& other) noexcept 
+    : m_arr{ other.m_arr }, m_capacity{ other.m_capacity }, m_size{ other.m_size }
 {
-    m_arr = other.m_arr;
-    m_capacity = other.m_capacity;
-    m_size = other.m_size;
-    
     other.m_arr = nullptr;
 }
 
 template <typename T>
 dynamicArray<T>& dynamicArray<T>::operator=(dynamicArray&& other) noexcept
 {
-    delete[] m_arr;
-    m_arr = other.m_arr;
-    m_capacity = other.m_capacity;
-    m_size = other.m_size;
-
-    other.m_arr = nullptr;
+    // Guard self assignment
+    if (this != &other)
+    {
+        dynamicArray<T> tempArr(std::move(other));
+        std::swap(m_arr, tempArr.m_arr);
+        std::swap(m_capacity, tempArr.m_capacity);
+        std::swap(m_size, tempArr.m_size);
+    }
     return *this;
 }
 
@@ -169,7 +170,7 @@ const T& dynamicArray<T>::operator[](const int index) const
 }
 
 template <typename T>
-void dynamicArray<T>::append(const T elem)
+void dynamicArray<T>::append(const T& elem)
 {
     // out of memory, expand array
     if (m_size == m_capacity)
@@ -181,7 +182,7 @@ void dynamicArray<T>::append(const T elem)
 }
 
 template <typename T>
-void dynamicArray<T>::insert(const T elem, const int index)
+void dynamicArray<T>::insert(const T& elem, const int index)
 {
     if ((index < 0) || (index > m_size))
         throw std::out_of_range("Out of array bounds");
@@ -205,6 +206,18 @@ template <typename T>
 int dynamicArray<T>::size() const
 {
     return m_size;
+}
+
+template <typename T>
+T* dynamicArray<T>::begin() const
+{
+    return m_arr;
+}
+
+template <typename T>
+T* dynamicArray<T>::end() const
+{
+    return m_arr + m_size;
 }
 
 #endif /* DYNAMIC_ARRAY_H */

--- a/test/dynamicArrayTest.cpp
+++ b/test/dynamicArrayTest.cpp
@@ -133,6 +133,17 @@ TEST(dynamicArrayIntSuite, InsertElement)
 	EXPECT_EQ(arr[3], 40);
 }
 
+TEST(dynamicArrayIntSuite, InsertElementAtEnd)
+{
+	dynamicArray<int> arr{ 10, 20, 30, 35 };
+	arr.insert(40, 4);
+	EXPECT_EQ(arr[0], 10);
+	EXPECT_EQ(arr[1], 20);
+	EXPECT_EQ(arr[2], 30);
+	EXPECT_EQ(arr[3], 35);
+	EXPECT_EQ(arr[4], 40);
+}
+
 TEST(dynamicArrayIntSuite, ReplaceExistingElement)
 {
 	dynamicArray<int> arr{ 30, 20, 0, 50 };
@@ -141,6 +152,19 @@ TEST(dynamicArrayIntSuite, ReplaceExistingElement)
 	EXPECT_EQ(arr[1], 20);
 	EXPECT_EQ(arr[2], 10);
 	EXPECT_EQ(arr[3], 50);
+}
+
+TEST(dynamicArrayIntSuite, RangeLoop)
+{
+	dynamicArray<int> arr{ 1, 2, 3, 4 };
+	for (auto& elem : arr)
+	{
+		elem = elem * elem;
+	}
+	EXPECT_EQ(arr[0], 1);
+	EXPECT_EQ(arr[1], 4);
+	EXPECT_EQ(arr[2], 9);
+	EXPECT_EQ(arr[3], 16);
 }
 
 // ---------------------------------------------------------------------
@@ -274,6 +298,16 @@ TEST(dynamicArrayDoubleSuite, InsertElements)
 	EXPECT_EQ(arr[3], 0.4);
 }
 
+TEST(dynamicArrayDoubleSuite, InsertElementAtEnd)
+{
+	dynamicArray<double> arr{ 0.1, 0.2, 0.3 };
+	arr.insert(0.4, 3);
+	EXPECT_EQ(arr[0], 0.1);
+	EXPECT_EQ(arr[1], 0.2);
+	EXPECT_EQ(arr[2], 0.3);
+	EXPECT_EQ(arr[3], 0.4);
+}
+
 TEST(dynamicArrayDoubleSuite, ReplaceExistingElement)
 {
 	dynamicArray<double> arr{ 1.5, 3.0, 0.0 };
@@ -281,4 +315,17 @@ TEST(dynamicArrayDoubleSuite, ReplaceExistingElement)
 	EXPECT_EQ(arr[0], 1.5);
 	EXPECT_EQ(arr[1], 3.0);
 	EXPECT_EQ(arr[2], 3.3333);
+}
+
+TEST(dynamicArrayDoubleSuite, RangeLoop)
+{
+	dynamicArray<double> arr{ 1.0, 2.0, 3.0, 4.0 };
+	for (auto& elem : arr)
+	{
+		elem = elem + elem;
+	}
+	EXPECT_EQ(arr[0], 2.0);
+	EXPECT_EQ(arr[1], 4.0);
+	EXPECT_EQ(arr[2], 6.0);
+	EXPECT_EQ(arr[3], 8.0);
 }


### PR DESCRIPTION
- Add begin and end functions to support range-based for loops and iterator-based operations
- Use "copy and swap" idiom to simplify the code and ensure strong exception safety
- Insert and append now pass argument by reference
- More unit tests